### PR TITLE
feat: Add keywords support and enhance SEO in posts

### DIFF
--- a/app/src/lib/types/index.ts
+++ b/app/src/lib/types/index.ts
@@ -14,6 +14,7 @@ export interface Post {
         mainImageUrl?: string; // For compatibility
     };
     tags?: string[];
+    keywords?: string[];
     body: PortableTextBlock[];
 }
 
@@ -28,7 +29,7 @@ export interface PocketBasePost {
     excerpt?: string;
     mainImage?: string;
     tags?: string[];
-    keywords?: string; // JSON string
+    keywords?: string[] | string; // array from API or JSON string
     body?: string; // JSON string
     status?: string;
 }

--- a/app/src/routes/post/[slug]/+page.svelte
+++ b/app/src/routes/post/[slug]/+page.svelte
@@ -25,6 +25,11 @@
 
 	const articleUrl = `https://www.sportsunlimited.ng/post/${data.slug.current}`;
 
+	const metaKeywords = $derived.by(() => {
+		const k = (data.keywords?.length ? data.keywords : data.tags)?.join(', ');
+		return k ? `${k}, Nigerian sports news, sports unlimited` : 'Nigerian sports news, sports unlimited';
+	});
+
 	function copyLink() {
 		navigator.clipboard.writeText(articleUrl).then(() => {
 			linkCopied = true;
@@ -137,7 +142,7 @@
 	<meta name="twitter:image:alt" content={data.title} />
 	
 	<!-- Additional SEO meta tags -->
-	<meta name="keywords" content={data.tags ? data.tags.join(', ') + ', Nigerian sports news, sports unlimited' : 'Nigerian sports news, sports unlimited'} />
+	<meta name="keywords" content={metaKeywords} />
 	<meta name="author" content="Sports Unlimited" />
 	<meta name="publisher" content="Sports Unlimited" />
 	<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
@@ -184,7 +189,7 @@
 			"@id": "https://www.sportsunlimited.ng/post/${data.slug.current}"
 		},
 		"articleSection": "Sports",
-		"keywords": "${data.tags ? data.tags.join(', ') : 'Nigerian sports news'}",
+		"keywords": "${(data.keywords?.length ? data.keywords : data.tags)?.join(', ') || 'Nigerian sports news'}",
 		"url": "https://www.sportsunlimited.ng/post/${data.slug.current}",
 		"wordCount": "${data.body ? JSON.stringify(data.body).split(' ').length : 0}"
 	}


### PR DESCRIPTION
- Introduced a new `keywords` field in the Post and PocketBasePost interfaces to support multiple keyword formats.
- Updated the transformPost function to parse keywords from PocketBase, accommodating both arrays and JSON strings.
- Enhanced SEO metadata generation in post pages to include keywords, improving search visibility.
- Refined sitemap generation logic to ensure accurate representation of posts and tags.